### PR TITLE
fix: xp bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idle-ant-farm",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "idle-ant-farm",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@fortawesome/free-regular-svg-icons": "^6.6.0",
         "@owliehq/vue-addtohomescreen": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idle-ant-farm",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "scripts": {
     "dev": "vite --mode localhost",
     "build": "rm -rf dist && vite build",

--- a/src/stores/trainingStore.ts
+++ b/src/stores/trainingStore.ts
@@ -522,7 +522,7 @@ export const useTrainingStore = defineStore({
 
     addLevelToMiningResource(resource: MiningResource) {
       resource.level++
-      resource.xp = 0
+      resource.xp -= resource.xpToNextLevel
       resource.xpToNextLevel = this.getXpToNextLevel(resource.level)
 
       this.checkAndApplyMileStoneBonusses(resource)
@@ -667,7 +667,7 @@ export const useTrainingStore = defineStore({
       if (!training) return
 
       training.level++
-      training.xp = 0
+      training.xp -= training.xpToNextLevel
       training.xpToNextLevel = this.getXpToNextLevel(training.level)
 
       if (skill === Skill.Mining) this.checkMiningMilestones()


### PR DESCRIPTION
xp got reset to zero on skill/resource level up even if the xp gained was over the xp amount left until level up, leftover xp now carries over to the next level